### PR TITLE
Add Dockerfile for CD

### DIFF
--- a/Evaluation/Dockerfile
+++ b/Evaluation/Dockerfile
@@ -1,0 +1,14 @@
+### Employ the builder pattern
+FROM maven:3.6.1-jdk-8 as builder
+
+### Provide Default Argument
+WORKDIR /usr/src/app 
+COPY . .
+RUN mvn clean package
+
+## Use only a JRE to run application
+FROM gcr.io/distroless/java:8
+## Copy Artifact from maven image
+COPY --from=builder /usr/src/app/target/Evaluation-0.0.1-SNAPSHOT.jar /app/app.jar 
+WORKDIR /app 
+CMD ["app.jar"]


### PR DESCRIPTION
With CI functioning properly, add a Dockerfile to be used for CD Sanity Testing.
If deployment works as expected, will provide Dockerfiles for other repositories and notify both Teams of where they can access the hosted API's.